### PR TITLE
fixed copy command error notify bug

### DIFF
--- a/src/django_tui/management/commands/tui.py
+++ b/src/django_tui/management/commands/tui.py
@@ -256,7 +256,7 @@ class DjangoCommandBuilder(Screen):
             return
 
         if sys.platform == "win32":
-            copy_command = ["copy"]
+            copy_command = ["clip"]
         elif sys.platform == "darwin":
             copy_command = ["pbcopy"]
         else:

--- a/src/django_tui/management/commands/tui.py
+++ b/src/django_tui/management/commands/tui.py
@@ -272,7 +272,7 @@ class DjangoCommandBuilder(Screen):
             )
             self.notify(f"`{command}` copied to clipboard.")
         except FileNotFoundError:
-            self.notify(f"Could not copy to clipboard. `{cmd[0]}` not found.", severity="error")
+            self.notify(f"Could not copy to clipboard. `{copy_command[0]}` not found.", severity="error")
 
     def action_about(self) -> None:
         self.app.push_screen(AboutDialog())


### PR DESCRIPTION
Fixes:
- Use "clip" to copy to clipboard in windows. The "copy" command is used to copy files.
- fixed name mismatch in notify when copy command fails.